### PR TITLE
Add voting type selection (Fibonacci or T-shirt sizes)

### DIFF
--- a/cdk/lambda/handlers/createSession.ts
+++ b/cdk/lambda/handlers/createSession.ts
@@ -10,7 +10,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   try {
     const body: CreateSessionMessage = JSON.parse(event.body || '{}');
-    const { sessionName, userName, userId } = body;
+    const { sessionName, userName, userId, votingType = 'fibonacci' } = body;
 
     if (!sessionName || !userName || !userId) {
       return {
@@ -37,6 +37,7 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
       createdAt: Date.now(),
       participants: [participant],
       isRevealed: false,
+      votingType,
     };
 
     // Save session to DynamoDB

--- a/cdk/lambda/types/index.ts
+++ b/cdk/lambda/types/index.ts
@@ -1,4 +1,8 @@
-export type CardValue = '0' | '1' | '2' | '3' | '5' | '8' | '13' | '20' | '40' | '100' | '?' | '☕';
+export type VotingType = 'fibonacci' | 'tshirt';
+
+export type FibonacciCardValue = '0' | '1' | '2' | '3' | '5' | '8' | '13' | '20' | '40' | '100' | '?' | '☕';
+export type TShirtCardValue = 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL' | '?' | '☕';
+export type CardValue = FibonacciCardValue | TShirtCardValue;
 
 export interface Participant {
   id: string;
@@ -14,6 +18,7 @@ export interface Session {
   createdAt: number;
   participants: Participant[];
   isRevealed: boolean;
+  votingType: VotingType;
 }
 
 export interface Connection {
@@ -32,6 +37,7 @@ export interface CreateSessionMessage {
   sessionName: string;
   userName: string;
   userId: string;
+  votingType?: VotingType;
 }
 
 export interface JoinSessionMessage {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
 
 // Mock child components
@@ -31,6 +32,14 @@ vi.mock('./components/SessionView', () => ({
   ),
 }));
 
+const renderApp = () => {
+  return render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
+};
+
 describe('App', () => {
   beforeEach(() => {
     // Clear URL params
@@ -38,23 +47,31 @@ describe('App', () => {
   });
 
   it('should render SessionCreate by default', () => {
-    render(<App />);
+    renderApp();
     expect(screen.getByText('Session Create Component')).toBeInTheDocument();
   });
 
   it('should render SessionJoin when join param is present', () => {
     window.history.pushState({}, '', '?join=test-session-123');
-    render(<App />);
+    renderApp();
     expect(screen.getByText(/Session Join Component - test-session-123/)).toBeInTheDocument();
   });
 
   it('should transition to SessionView after creating session', async () => {
-    const { rerender } = render(<App />);
+    const { rerender } = render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
     
     const createButton = screen.getByText('Create');
     createButton.click();
     
-    rerender(<App />);
+    rerender(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
     
     expect(screen.getByText('Session View Component')).toBeInTheDocument();
     expect(screen.getByText('Session: test-session')).toBeInTheDocument();
@@ -63,12 +80,20 @@ describe('App', () => {
 
   it('should transition to SessionView after joining session', async () => {
     window.history.pushState({}, '', '?join=existing-session');
-    const { rerender } = render(<App />);
+    const { rerender } = render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
     
     const joinButton = screen.getByText('Join');
     joinButton.click();
     
-    rerender(<App />);
+    rerender(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
     
     expect(screen.getByText('Session View Component')).toBeInTheDocument();
     expect(screen.getByText('Session: existing-session')).toBeInTheDocument();
@@ -78,7 +103,7 @@ describe('App', () => {
   it('should update URL when session is created', async () => {
     const pushStateSpy = vi.spyOn(window.history, 'pushState');
     
-    render(<App />);
+    renderApp();
     
     const createButton = screen.getByText('Create');
     createButton.click();
@@ -93,7 +118,7 @@ describe('App', () => {
     
     // Mock to return null session state somehow - in this case we can't easily
     // so we'll just verify the basic rendering works
-    render(<App />);
+    renderApp();
     expect(screen.getByText(/Session Join Component/)).toBeInTheDocument();
   });
 });

--- a/src/components/SessionCreate.test.tsx
+++ b/src/components/SessionCreate.test.tsx
@@ -82,7 +82,8 @@ describe('SessionCreate', () => {
 
   it('should generate unique IDs for session and user', async () => {
     const user = userEvent.setup();
-    vi.mocked(storage.generateId).mockReturnValueOnce('session-123').mockReturnValueOnce('user-456');
+    // userId is generated first, then sessionId in the implementation
+    vi.mocked(storage.generateId).mockReturnValueOnce('user-456').mockReturnValueOnce('session-123');
     
     render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
     

--- a/src/components/SessionCreate.tsx
+++ b/src/components/SessionCreate.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import type { Session } from '@/types';
+import type { Session, VotingType } from '@/types';
+import { VOTING_TYPE_LABELS } from '@/types';
 import { storage } from '@/lib/storage';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import type { WebSocketMessage } from '@/lib/api';
@@ -14,6 +15,7 @@ interface SessionCreateProps {
 export function SessionCreate({ onSessionCreated }: SessionCreateProps) {
   const [sessionName, setSessionName] = useState('');
   const [userName, setUserName] = useState('');
+  const [votingType, setVotingType] = useState<VotingType>('fibonacci');
   const { wsClient, isBackendAvailable, connect, addMessageHandler, removeMessageHandler } = useWebSocket();
 
   // Connect to WebSocket on mount
@@ -51,7 +53,7 @@ export function SessionCreate({ onSessionCreated }: SessionCreateProps) {
 
     // Use WebSocket if available
     if (isBackendAvailable && wsClient) {
-      wsClient.createSession(sessionName, userName, userId);
+      wsClient.createSession(sessionName, userName, userId, votingType);
     } else {
       // Fallback to localStorage
       const sessionId = storage.generateId();
@@ -69,6 +71,7 @@ export function SessionCreate({ onSessionCreated }: SessionCreateProps) {
         ],
         isRevealed: false,
         currentUserId: userId,
+        votingType,
       };
 
       storage.saveSession(newSession);
@@ -103,6 +106,20 @@ export function SessionCreate({ onSessionCreated }: SessionCreateProps) {
               onChange={(e) => setSessionName(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && createSession()}
             />
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-1.5 block">Voting Type</label>
+            <select
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              value={votingType}
+              onChange={(e) => setVotingType(e.target.value as VotingType)}
+            >
+              {(Object.keys(VOTING_TYPE_LABELS) as VotingType[]).map((type) => (
+                <option key={type} value={type}>
+                  {VOTING_TYPE_LABELS[type]}
+                </option>
+              ))}
+            </select>
           </div>
           <Button onClick={createSession} className="w-full" disabled={!sessionName.trim() || !userName.trim()}>
             Create Session

--- a/src/components/SessionJoin.test.tsx
+++ b/src/components/SessionJoin.test.tsx
@@ -22,6 +22,7 @@ describe('SessionJoin', () => {
     participants: [],
     isRevealed: false,
     currentUserId: 'user-1',
+    votingType: 'fibonacci',
   };
 
   beforeEach(() => {

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -1,13 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { PokerCard } from '@/components/PokerCard';
 import { ParticipantList } from '@/components/ParticipantList';
 import type { CardValue } from '@/types';
+import { FIBONACCI_VALUES, TSHIRT_VALUES } from '@/types';
 import { useSession } from '@/hooks/useSession';
 import { useSettings } from '@/contexts/SettingsContext';
-
-const CARD_VALUES: CardValue[] = ['0', '1', '2', '3', '5', '8', '13', '20', '40', '100', '?', '☕'];
 
 interface SessionViewProps {
   sessionId: string;
@@ -18,6 +17,11 @@ export function SessionView({ sessionId, currentUserId }: SessionViewProps) {
   const { session, selectCard, revealCards, resetVoting } = useSession(sessionId, currentUserId);
   const { settings } = useSettings();
   const [shareLink] = useState(`${window.location.origin}?join=${sessionId}`);
+
+  const cardValues = useMemo(() => {
+    if (!session) return FIBONACCI_VALUES;
+    return session.votingType === 'tshirt' ? TSHIRT_VALUES : FIBONACCI_VALUES;
+  }, [session?.votingType]);
 
   const currentParticipant = session?.participants.find((p) => p.id === currentUserId);
   const allReady = session?.participants.every((p) => p.isReady) ?? false;
@@ -76,12 +80,12 @@ export function SessionView({ sessionId, currentUserId }: SessionViewProps) {
               </CardHeader>
               <CardContent>
                 <div className="flex flex-wrap gap-3 justify-center">
-                  {CARD_VALUES.map((value) => (
+                  {cardValues.map((value) => (
                     <PokerCard
                       key={value}
-                      value={value}
+                      value={value as CardValue}
                       isSelected={currentParticipant?.selectedCard === value}
-                      onClick={() => handleCardSelect(value)}
+                      onClick={() => handleCardSelect(value as CardValue)}
                       disabled={session.isRevealed}
                     />
                   ))}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { config } from '@/config/env';
-import type { CardValue } from '@/types';
+import type { CardValue, VotingType } from '@/types';
 
 export type WebSocketMessageType =
   | 'sessionCreated'
@@ -125,10 +125,10 @@ export class WebSocketClient {
   }
 
   // Session operations
-  createSession(sessionName: string, userName: string, userId: string): void {
+  createSession(sessionName: string, userName: string, userId: string, votingType: VotingType = 'fibonacci'): void {
     this.sessionId = null; // Will be set when we receive sessionCreated
     this.participantId = userId;
-    this.send('createSession', { sessionName, userName, userId });
+    this.send('createSession', { sessionName, userName, userId, votingType });
   }
 
   joinSession(sessionId: string, userName: string, userId: string): void {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -49,6 +49,7 @@ describe('storage', () => {
         participants: [],
         isRevealed: false,
         currentUserId: 'user1',
+        votingType: 'fibonacci',
       };
       localStorage.setItem('planning-poker-sessions', JSON.stringify({
         'session1': mockSession,
@@ -68,6 +69,7 @@ describe('storage', () => {
         participants: [],
         isRevealed: false,
         currentUserId: 'user1',
+        votingType: 'fibonacci',
       };
 
       storage.saveSession(mockSession);
@@ -84,6 +86,7 @@ describe('storage', () => {
         participants: [],
         isRevealed: false,
         currentUserId: 'user1',
+        votingType: 'fibonacci',
       };
 
       storage.saveSession(mockSession);
@@ -103,6 +106,7 @@ describe('storage', () => {
         participants: [],
         isRevealed: false,
         currentUserId: 'user1',
+        votingType: 'fibonacci',
       };
 
       const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
@@ -128,6 +132,7 @@ describe('storage', () => {
         participants: [],
         isRevealed: false,
         currentUserId: 'user1',
+        votingType: 'fibonacci',
       };
 
       storage.saveSession(mockSession);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,16 @@
-export type CardValue = '0' | '1' | '2' | '3' | '5' | '8' | '13' | '20' | '40' | '100' | '?' | '☕';
+export type VotingType = 'fibonacci' | 'tshirt';
+
+export type FibonacciCardValue = '0' | '1' | '2' | '3' | '5' | '8' | '13' | '20' | '40' | '100' | '?' | '☕';
+export type TShirtCardValue = 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL' | '?' | '☕';
+export type CardValue = FibonacciCardValue | TShirtCardValue;
+
+export const FIBONACCI_VALUES: FibonacciCardValue[] = ['0', '1', '2', '3', '5', '8', '13', '20', '40', '100', '?', '☕'];
+export const TSHIRT_VALUES: TShirtCardValue[] = ['XS', 'S', 'M', 'L', 'XL', 'XXL', '?', '☕'];
+
+export const VOTING_TYPE_LABELS: Record<VotingType, string> = {
+  fibonacci: 'Fibonacci (0, 1, 2, 3, 5, 8...)',
+  tshirt: 'T-Shirt Sizes (XS, S, M, L...)',
+};
 
 export interface Participant {
   id: string;
@@ -15,6 +27,7 @@ export interface Session {
   participants: Participant[];
   isRevealed: boolean;
   currentUserId: string;
+  votingType: VotingType;
 }
 
 export interface StoredSessions {


### PR DESCRIPTION
## Summary

This PR adds the ability to choose a voting type when creating a new planning poker session. Users can now select between:

- **Fibonacci** (0, 1, 2, 3, 5, 8, 13, 20, 40, 100, ?, ☕) - the existing default
- **T-Shirt Sizes** (XS, S, M, L, XL, XXL, ?, ☕) - a new option

## Changes

### Types
- Added `VotingType` type (`'fibonacci' | 'tshirt'`)
- Added card value arrays for each voting type
- Added `votingType` field to `Session` interface (both frontend and backend)

### Frontend
- Added voting type dropdown to the session creation form
- Updated `SessionView` to dynamically display card values based on the session's voting type
- Updated WebSocket client to include voting type when creating sessions
- Updated localStorage fallback to include voting type

### Backend
- Updated `createSession` lambda handler to accept and store the voting type (defaults to 'fibonacci')

### Tests
- Updated test files to include `votingType` in mock session objects
- Fixed test expectations for correct mock value ordering

## Screenshots

The session creation form now includes a "Voting Type" dropdown selector.

---

_This PR was generated with [Warp](https://www.warp.dev/)._
