### PR TITLE
Add session navigation and emoji reactions features

### DIFF
--- a/cdk/lambda/handlers/sendReaction.ts
+++ b/cdk/lambda/handlers/sendReaction.ts
@@ -1,0 +1,84 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getSession, updateParticipant } from '../utils/dynamodb';
+import { broadcastToSession } from '../utils/broadcast';
+import { SendReactionMessage, Reaction } from '../types';
+
+export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log('SendReaction event:', JSON.stringify(event, null, 2));
+
+  try {
+    const body: SendReactionMessage = JSON.parse(event.body || '{}');
+    const { sessionId, fromUserId, toUserId, emoji } = body;
+
+    if (!sessionId || !fromUserId || !toUserId || !emoji) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Missing required fields' }),
+      };
+    }
+
+    const session = await getSession(sessionId);
+    if (!session) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({ error: 'Session not found' }),
+      };
+    }
+
+    // Find the target participant
+    const targetParticipant = session.participants.find((p) => p.id === toUserId);
+    if (!targetParticipant) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({ error: 'Participant not found' }),
+      };
+    }
+
+    // Create the reaction
+    const reaction: Reaction = {
+      id: Math.random().toString(36).substring(2, 9),
+      emoji,
+      fromUserId,
+      toUserId,
+      timestamp: Date.now(),
+    };
+
+    // Update participant with new reaction
+    const existingReactions = targetParticipant.reactions || [];
+    // Keep only recent reactions (last 10 seconds) and add new one
+    const recentReactions = existingReactions.filter(
+      (r) => Date.now() - r.timestamp < 10000
+    );
+    const updatedReactions = [...recentReactions, reaction];
+
+    const updatedSession = await updateParticipant(sessionId, toUserId, {
+      reactions: updatedReactions,
+    });
+
+    if (!updatedSession) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'Failed to update participant' }),
+      };
+    }
+
+    // Broadcast to all participants in the session
+    await broadcastToSession(sessionId, {
+      type: 'reactionSent',
+      data: updatedSession,
+    });
+
+    console.log(`Reaction ${emoji} sent from ${fromUserId} to ${toUserId} in session ${sessionId}`);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true }),
+    };
+  } catch (error) {
+    console.error('Error sending reaction:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to send reaction' }),
+    };
+  }
+}

--- a/cdk/lambda/types/index.ts
+++ b/cdk/lambda/types/index.ts
@@ -4,12 +4,21 @@ export type FibonacciCardValue = '0' | '1' | '2' | '3' | '5' | '8' | '13' | '20'
 export type TShirtCardValue = 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL' | '?' | '☕';
 export type CardValue = FibonacciCardValue | TShirtCardValue;
 
+export interface Reaction {
+  id: string;
+  emoji: string;
+  fromUserId: string;
+  toUserId: string;
+  timestamp: number;
+}
+
 export interface Participant {
   id: string;
   name: string;
   selectedCard?: CardValue;
   isReady: boolean;
   lastSeen: number;
+  reactions?: Reaction[];
 }
 
 export interface Session {
@@ -64,4 +73,11 @@ export interface ResetVotingMessage {
 export interface HeartbeatMessage {
   sessionId: string;
   participantId: string;
+}
+
+export interface SendReactionMessage {
+  sessionId: string;
+  fromUserId: string;
+  toUserId: string;
+  emoji: string;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,12 +85,37 @@ function App() {
     saveUserState(sessionId, newUserId);
   };
 
+  const handleNewSession = () => {
+    // Clear saved user state and go to create screen
+    localStorage.removeItem(SESSION_STATE_KEY);
+    setSessionId(null);
+    setUserId(null);
+    setAppState('create');
+    window.history.pushState({}, '', window.location.pathname);
+  };
+
+  const handleJoinDifferentSession = (newSessionId?: string) => {
+    // Allow joining a different session or as a different user
+    localStorage.removeItem(SESSION_STATE_KEY);
+    setUserId(null);
+    if (newSessionId) {
+      setSessionId(newSessionId);
+      setAppState('join');
+      window.history.pushState({}, '', `?join=${newSessionId}`);
+    } else if (sessionId) {
+      setAppState('join');
+    } else {
+      setAppState('create');
+      window.history.pushState({}, '', window.location.pathname);
+    }
+  };
+
   return (
     <>
       <MenuBar />
-      {appState === 'create' && <SessionCreate onSessionCreated={handleSessionCreated} />}
-      {appState === 'join' && sessionId && <SessionJoin sessionId={sessionId} onJoined={handleJoined} />}
-      {appState === 'session' && sessionId && userId && <SessionView sessionId={sessionId} currentUserId={userId} />}
+      {appState === 'create' && <SessionCreate onSessionCreated={handleSessionCreated} onJoinExisting={handleJoinDifferentSession} />}
+      {appState === 'join' && sessionId && <SessionJoin sessionId={sessionId} onJoined={handleJoined} onNewSession={handleNewSession} onJoinDifferent={handleJoinDifferentSession} />}
+      {appState === 'session' && sessionId && userId && <SessionView sessionId={sessionId} currentUserId={userId} onNewSession={handleNewSession} onJoinDifferent={handleJoinDifferentSession} />}
       {appState !== 'create' && appState !== 'join' && appState !== 'session' && <div>Loading...</div>}
     </>
   );

--- a/src/components/ParticipantList.test.tsx
+++ b/src/components/ParticipantList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ParticipantList } from './ParticipantList';
 import type { Participant } from '@/types';
@@ -20,39 +20,47 @@ describe('ParticipantList', () => {
     },
   ];
 
+  const mockOnReaction = vi.fn();
+  const defaultProps = {
+    participants: mockParticipants,
+    isRevealed: false,
+    currentUserId: 'current-user',
+    onReaction: mockOnReaction,
+  };
+
   it('should render participant count', () => {
-    render(<ParticipantList participants={mockParticipants} isRevealed={false} />);
+    render(<ParticipantList {...defaultProps} />);
     expect(screen.getByText(/Participants \(2\)/i)).toBeInTheDocument();
   });
 
   it('should render all participant names', () => {
-    render(<ParticipantList participants={mockParticipants} isRevealed={false} />);
+    render(<ParticipantList {...defaultProps} />);
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('Bob')).toBeInTheDocument();
   });
 
   it('should show ready status when participant is ready but not revealed', () => {
-    render(<ParticipantList participants={mockParticipants} isRevealed={false} />);
+    render(<ParticipantList {...defaultProps} />);
     expect(screen.getByText(/🂠 Ready/i)).toBeInTheDocument();
   });
 
   it('should show thinking status when participant is not ready', () => {
-    render(<ParticipantList participants={mockParticipants} isRevealed={false} />);
+    render(<ParticipantList {...defaultProps} />);
     expect(screen.getByText(/Thinking.../i)).toBeInTheDocument();
   });
 
   it('should show selected cards when revealed', () => {
-    render(<ParticipantList participants={mockParticipants} isRevealed={true} />);
+    render(<ParticipantList {...defaultProps} isRevealed={true} />);
     expect(screen.getByText('5')).toBeInTheDocument();
   });
 
   it('should not show ready status when revealed', () => {
-    render(<ParticipantList participants={mockParticipants} isRevealed={true} />);
+    render(<ParticipantList {...defaultProps} isRevealed={true} />);
     expect(screen.queryByText(/🂠 Ready/i)).not.toBeInTheDocument();
   });
 
   it('should handle empty participant list', () => {
-    render(<ParticipantList participants={[]} isRevealed={false} />);
+    render(<ParticipantList {...defaultProps} participants={[]} />);
     expect(screen.getByText(/Participants \(0\)/i)).toBeInTheDocument();
   });
 
@@ -65,7 +73,7 @@ describe('ParticipantList', () => {
         lastSeen: Date.now(),
       },
     ];
-    render(<ParticipantList participants={participants} isRevealed={true} />);
+    render(<ParticipantList {...defaultProps} participants={participants} isRevealed={true} />);
     expect(screen.getByText('Charlie')).toBeInTheDocument();
     // Should not show a card value, only participant count is visible
     const participantRow = screen.getByText('Charlie').closest('div');

--- a/src/components/ParticipantList.tsx
+++ b/src/components/ParticipantList.tsx
@@ -1,12 +1,72 @@
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import type { Participant } from '@/types';
+import { Button } from '@/components/ui/button';
+import type { Participant, Reaction } from '@/types';
+import { REACTION_EMOJIS } from '@/types';
 
 interface ParticipantListProps {
   participants: Participant[];
   isRevealed: boolean;
+  currentUserId: string;
+  onReaction: (toUserId: string, emoji: string) => void;
 }
 
-export function ParticipantList({ participants, isRevealed }: ParticipantListProps) {
+function ReactionDisplay({ reactions }: { reactions?: Reaction[] }) {
+  const [visibleReactions, setVisibleReactions] = useState<Reaction[]>([]);
+
+  useEffect(() => {
+    if (!reactions) {
+      setVisibleReactions([]);
+      return;
+    }
+
+    // Filter to only show recent reactions (last 5 seconds)
+    const filterReactions = () => {
+      const now = Date.now();
+      const recent = reactions.filter((r) => now - r.timestamp < 5000);
+      setVisibleReactions(recent);
+    };
+
+    filterReactions();
+    const interval = setInterval(filterReactions, 500);
+    return () => clearInterval(interval);
+  }, [reactions]);
+
+  if (visibleReactions.length === 0) return null;
+
+  return (
+    <div className="flex gap-1 animate-bounce">
+      {visibleReactions.map((reaction) => (
+        <span key={reaction.id} className="text-lg">
+          {reaction.emoji}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function EmojiPicker({ onSelect, onClose }: { onSelect: (emoji: string) => void; onClose: () => void }) {
+  return (
+    <div className="absolute right-0 top-full mt-1 z-10 bg-popover border rounded-md shadow-lg p-2 flex gap-1 flex-wrap max-w-[200px]">
+      {REACTION_EMOJIS.map((emoji) => (
+        <button
+          key={emoji}
+          onClick={() => {
+            onSelect(emoji);
+            onClose();
+          }}
+          className="text-xl hover:bg-accent rounded p-1 transition-colors"
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function ParticipantList({ participants, isRevealed, currentUserId, onReaction }: ParticipantListProps) {
+  const [openPickerId, setOpenPickerId] = useState<string | null>(null);
+
   return (
     <Card>
       <CardHeader>
@@ -17,9 +77,12 @@ export function ParticipantList({ participants, isRevealed }: ParticipantListPro
           {participants.map((participant) => (
             <div
               key={participant.id}
-              className="flex items-center justify-between p-3 rounded-md border"
+              className="flex items-center justify-between p-3 rounded-md border relative"
             >
-              <span className="font-medium">{participant.name}</span>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{participant.name}</span>
+                <ReactionDisplay reactions={participant.reactions} />
+              </div>
               <div className="flex items-center gap-2">
                 {participant.isReady && !isRevealed && (
                   <span className="text-sm text-muted-foreground">🂠 Ready</span>
@@ -29,6 +92,24 @@ export function ParticipantList({ participants, isRevealed }: ParticipantListPro
                 )}
                 {!participant.isReady && !isRevealed && (
                   <span className="text-sm text-muted-foreground">Thinking...</span>
+                )}
+                {participant.id !== currentUserId && (
+                  <div className="relative">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setOpenPickerId(openPickerId === participant.id ? null : participant.id)}
+                      className="text-lg p-1 h-auto"
+                    >
+                      😀
+                    </Button>
+                    {openPickerId === participant.id && (
+                      <EmojiPicker
+                        onSelect={(emoji) => onReaction(participant.id, emoji)}
+                        onClose={() => setOpenPickerId(null)}
+                      />
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/src/components/SessionCreate.test.tsx
+++ b/src/components/SessionCreate.test.tsx
@@ -13,6 +13,11 @@ vi.mock('@/lib/storage', () => ({
 
 describe('SessionCreate', () => {
   const mockOnSessionCreated = vi.fn();
+  const mockOnJoinExisting = vi.fn();
+  const defaultProps = {
+    onSessionCreated: mockOnSessionCreated,
+    onJoinExisting: mockOnJoinExisting,
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -20,7 +25,7 @@ describe('SessionCreate', () => {
   });
 
   it('should render form inputs', () => {
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     expect(screen.getByPlaceholderText(/enter your name/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/sprint 24 planning/i)).toBeInTheDocument();
@@ -28,7 +33,7 @@ describe('SessionCreate', () => {
   });
 
   it('should have disabled button when fields are empty', () => {
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     const button = screen.getByRole('button', { name: /create session/i });
     expect(button).toBeDisabled();
@@ -36,7 +41,7 @@ describe('SessionCreate', () => {
 
   it('should enable button when both fields are filled', async () => {
     const user = userEvent.setup();
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'John');
     await user.type(screen.getByPlaceholderText(/sprint 24 planning/i), 'Sprint 1');
@@ -47,7 +52,7 @@ describe('SessionCreate', () => {
 
   it('should create session and call callback', async () => {
     const user = userEvent.setup();
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'John');
     await user.type(screen.getByPlaceholderText(/sprint 24 planning/i), 'Sprint 1');
@@ -59,7 +64,7 @@ describe('SessionCreate', () => {
 
   it('should create session on Enter key in session name field', async () => {
     const user = userEvent.setup();
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'John');
     const sessionInput = screen.getByPlaceholderText(/sprint 24 planning/i);
@@ -71,7 +76,7 @@ describe('SessionCreate', () => {
 
   it('should not create session with only whitespace', async () => {
     const user = userEvent.setup();
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), '   ');
     await user.type(screen.getByPlaceholderText(/sprint 24 planning/i), '   ');
@@ -85,7 +90,7 @@ describe('SessionCreate', () => {
     // userId is generated first, then sessionId in the implementation
     vi.mocked(storage.generateId).mockReturnValueOnce('user-456').mockReturnValueOnce('session-123');
     
-    render(<SessionCreate onSessionCreated={mockOnSessionCreated} />);
+    render(<SessionCreate {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'John');
     await user.type(screen.getByPlaceholderText(/sprint 24 planning/i), 'Sprint 1');

--- a/src/components/SessionCreate.tsx
+++ b/src/components/SessionCreate.tsx
@@ -10,12 +10,14 @@ import type { WebSocketMessage } from '@/lib/api';
 
 interface SessionCreateProps {
   onSessionCreated: (sessionId: string, userId: string) => void;
+  onJoinExisting: (sessionId?: string) => void;
 }
 
-export function SessionCreate({ onSessionCreated }: SessionCreateProps) {
+export function SessionCreate({ onSessionCreated, onJoinExisting }: SessionCreateProps) {
   const [sessionName, setSessionName] = useState('');
   const [userName, setUserName] = useState('');
   const [votingType, setVotingType] = useState<VotingType>('fibonacci');
+  const [joinSessionCode, setJoinSessionCode] = useState('');
   const { wsClient, isBackendAvailable, connect, addMessageHandler, removeMessageHandler } = useWebSocket();
 
   // Connect to WebSocket on mount
@@ -124,6 +126,25 @@ export function SessionCreate({ onSessionCreated }: SessionCreateProps) {
           <Button onClick={createSession} className="w-full" disabled={!sessionName.trim() || !userName.trim()}>
             Create Session
           </Button>
+          
+          <div className="border-t pt-4 mt-4">
+            <p className="text-sm text-muted-foreground mb-2">Or join an existing session:</p>
+            <div className="flex gap-2">
+              <Input
+                placeholder="Enter session code"
+                value={joinSessionCode}
+                onChange={(e) => setJoinSessionCode(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && joinSessionCode.trim() && onJoinExisting(joinSessionCode.trim())}
+              />
+              <Button 
+                variant="outline" 
+                onClick={() => onJoinExisting(joinSessionCode.trim())}
+                disabled={!joinSessionCode.trim()}
+              >
+                Join
+              </Button>
+            </div>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/SessionJoin.test.tsx
+++ b/src/components/SessionJoin.test.tsx
@@ -15,6 +15,8 @@ vi.mock('@/lib/storage', () => ({
 
 describe('SessionJoin', () => {
   const mockOnJoined = vi.fn();
+  const mockOnNewSession = vi.fn();
+  const mockOnJoinDifferent = vi.fn();
   const mockSession: Session = {
     id: 'session-123',
     name: 'Test Session',
@@ -24,6 +26,12 @@ describe('SessionJoin', () => {
     currentUserId: 'user-1',
     votingType: 'fibonacci',
   };
+  const defaultProps = {
+    sessionId: 'session-123',
+    onJoined: mockOnJoined,
+    onNewSession: mockOnNewSession,
+    onJoinDifferent: mockOnJoinDifferent,
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -32,7 +40,7 @@ describe('SessionJoin', () => {
   });
 
   it('should render join form', () => {
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     expect(screen.getByText(/join planning session/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/enter your name/i)).toBeInTheDocument();
@@ -40,7 +48,7 @@ describe('SessionJoin', () => {
   });
 
   it('should have disabled button when name is empty', () => {
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     const button = screen.getByRole('button', { name: /join session/i });
     expect(button).toBeDisabled();
@@ -48,7 +56,7 @@ describe('SessionJoin', () => {
 
   it('should enable button when name is entered', async () => {
     const user = userEvent.setup();
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'Jane');
     
@@ -58,7 +66,7 @@ describe('SessionJoin', () => {
 
   it('should join session and call callback', async () => {
     const user = userEvent.setup();
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'Jane');
     await user.click(screen.getByRole('button', { name: /join session/i }));
@@ -70,7 +78,7 @@ describe('SessionJoin', () => {
 
   it('should join session on Enter key', async () => {
     const user = userEvent.setup();
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     const input = screen.getByPlaceholderText(/enter your name/i);
     await user.type(input, 'Jane{Enter}');
@@ -84,7 +92,7 @@ describe('SessionJoin', () => {
     vi.mocked(storage.getSession).mockReturnValue(null);
     
     const user = userEvent.setup();
-    render(<SessionJoin sessionId="invalid-session" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} sessionId="invalid-session" />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'Jane');
     await user.click(screen.getByRole('button', { name: /join session/i }));
@@ -97,7 +105,7 @@ describe('SessionJoin', () => {
 
   it('should not join with only whitespace in name', async () => {
     const user = userEvent.setup();
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), '   ');
     
@@ -115,7 +123,7 @@ describe('SessionJoin', () => {
     vi.mocked(storage.getSession).mockReturnValue(sessionWithParticipants);
     
     const user = userEvent.setup();
-    render(<SessionJoin sessionId="session-123" onJoined={mockOnJoined} />);
+    render(<SessionJoin {...defaultProps} />);
     
     await user.type(screen.getByPlaceholderText(/enter your name/i), 'Bob');
     await user.click(screen.getByRole('button', { name: /join session/i }));

--- a/src/components/SessionJoin.tsx
+++ b/src/components/SessionJoin.tsx
@@ -9,10 +9,13 @@ import type { WebSocketMessage } from '@/lib/api';
 interface SessionJoinProps {
   sessionId: string;
   onJoined: (userId: string) => void;
+  onNewSession: () => void;
+  onJoinDifferent: (sessionId?: string) => void;
 }
 
-export function SessionJoin({ sessionId, onJoined }: SessionJoinProps) {
+export function SessionJoin({ sessionId, onJoined, onNewSession, onJoinDifferent }: SessionJoinProps) {
   const [userName, setUserName] = useState('');
+  const [joinSessionCode, setJoinSessionCode] = useState('');
   const { wsClient, isBackendAvailable, connect, addMessageHandler, removeMessageHandler } = useWebSocket();
 
   // Connect to WebSocket on mount
@@ -89,6 +92,7 @@ export function SessionJoin({ sessionId, onJoined }: SessionJoinProps) {
           <CardDescription>Enter your name to join the session</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">Session code: <code className="bg-muted px-1 rounded">{sessionId}</code></p>
           <div>
             <label className="text-sm font-medium mb-1.5 block">Your Name</label>
             <Input
@@ -100,6 +104,29 @@ export function SessionJoin({ sessionId, onJoined }: SessionJoinProps) {
           </div>
           <Button onClick={joinSession} className="w-full" disabled={!userName.trim()}>
             Join Session
+          </Button>
+          
+          <div className="border-t pt-4 mt-4">
+            <p className="text-sm text-muted-foreground mb-2">Or join a different session:</p>
+            <div className="flex gap-2">
+              <Input
+                placeholder="Enter session code"
+                value={joinSessionCode}
+                onChange={(e) => setJoinSessionCode(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && joinSessionCode.trim() && onJoinDifferent(joinSessionCode.trim())}
+              />
+              <Button 
+                variant="outline" 
+                onClick={() => onJoinDifferent(joinSessionCode.trim())}
+                disabled={!joinSessionCode.trim()}
+              >
+                Join
+              </Button>
+            </div>
+          </div>
+          
+          <Button onClick={onNewSession} variant="ghost" className="w-full">
+            Create New Session Instead
           </Button>
         </CardContent>
       </Card>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ export type WebSocketMessageType =
   | 'cardsRevealed'
   | 'votingReset'
   | 'sessionUpdate'
+  | 'reactionSent'
   | 'error';
 
 export interface WebSocketMessage {
@@ -148,6 +149,10 @@ export class WebSocketClient {
 
   resetVoting(sessionId: string): void {
     this.send('resetVoting', { sessionId });
+  }
+
+  sendReaction(sessionId: string, fromUserId: string, toUserId: string, emoji: string): void {
+    this.send('sendReaction', { sessionId, fromUserId, toUserId, emoji });
   }
 
   private startHeartbeat(): void {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,12 +12,23 @@ export const VOTING_TYPE_LABELS: Record<VotingType, string> = {
   tshirt: 'T-Shirt Sizes (XS, S, M, L...)',
 };
 
+export interface Reaction {
+  id: string;
+  emoji: string;
+  fromUserId: string;
+  toUserId: string;
+  timestamp: number;
+}
+
+export const REACTION_EMOJIS = ['👍', '👏', '🎉', '🔥', '❤️', '😂', '🤔', '👀'];
+
 export interface Participant {
   id: string;
   name: string;
   selectedCard?: CardValue;
   isReady: boolean;
   lastSeen: number;
+  reactions?: Reaction[];
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary

This PR adds three requested features to the Planning Poker application:

### 1. New Session Button
- Added a "New Session" button in the SessionView that allows users to leave the current session and start a fresh poker session
- Clears the stored user state and redirects to the create screen

### 2. Session Code Navigation
- Added session code input fields on all screens (create, join, and session views)
- Users can now easily join a different session by entering a session code
- This enables joining as a different user from another browser or tab since the user state is cleared when joining a different session

### 3. Emoji Reactions
- Users can react to other participants by clicking the emoji picker button next to their name
- Available reactions: 👍 👏 🎉 🔥 ❤️ 😂 🤔 👀
- Reactions display with a bounce animation next to the participant's name
- Reactions auto-fade after 5 seconds
- Full WebSocket support for real-time reaction broadcasting to all session participants
- Added `sendReaction` Lambda handler for backend support

## Changes

### Frontend
- `src/types/index.ts` - Added `Reaction` interface and `REACTION_EMOJIS` constant
- `src/App.tsx` - Added `handleNewSession` and `handleJoinDifferentSession` navigation handlers
- `src/components/SessionView.tsx` - Added New Session button, session code input, and reaction handling
- `src/components/SessionJoin.tsx` - Added session code input and navigation options
- `src/components/SessionCreate.tsx` - Added session code input to join existing sessions
- `src/components/ParticipantList.tsx` - Added emoji picker and reaction display with animations
- `src/hooks/useSession.ts` - Added `sendReaction` function with localStorage fallback
- `src/lib/api.ts` - Added `sendReaction` WebSocket method and `reactionSent` message type

### Backend (CDK Lambda)
- `cdk/lambda/types/index.ts` - Added `Reaction` interface and `SendReactionMessage` type
- `cdk/lambda/handlers/sendReaction.ts` - New handler for broadcasting reactions

### Tests
- Updated all test files with new required props

## Testing
- All 54 tests pass
- Build succeeds without TypeScript errors

_This PR was generated with [Warp](https://www.warp.dev/)._
